### PR TITLE
Make Access Control Methods Explicit

### DIFF
--- a/emulator/main.rb
+++ b/emulator/main.rb
@@ -27,7 +27,7 @@ end
 
 # HTTP Response boilerplate
 options '*' do
-  response.headers['ALLOW'] = 'GET, PUT, POST, DELETE, OPTIONS'
+  response.headers['Access-Control-Allow-Methods'] = 'GET, PUT, POST, DELETE, OPTIONS'
   response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, Accept, X-User-Email, X-Auth-Token'
 end
 


### PR DESCRIPTION
This pull request
- Makes the allowed methods explicit, since complications have been arising from CORS.