### PR TITLE
Update response status codes, fix broken image link in README, add API end-point tests, and add instructions to run API end-point tests, Bug fix, Add Snackbar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,9 @@ The [thoth-tech/ChatHistoryDisplayer](https://github.com/thoth-tech/ChatHistoryD
 
 2. Clone your fork of the repository. Replace `YOUR_GITHUB_USERNAME` in the following bash command with your GitHub username.
 
-  ```bash
-  git clone https://github.com/YOUR_GITHUB_USERNAME/ChatHistoryDisplayer.git
-  ```
+    ```bash
+    git clone https://github.com/YOUR_GITHUB_USERNAME/ChatHistoryDisplayer.git
+    ```
 
 3. Navigate into the `ChatHistoryDisplayer` directory with `cd ChatHistoryDisplayer`.
 
@@ -99,7 +99,8 @@ It is advised that all branches begin with a prefix followed by a name that expl
 Ensure your git global text editor is one you are comfortable with. After that, commits should omit the `-m` flag so that it opens up your favourite text editor. That is, instead of `git commit -m "A_MESSAGE`, you are advised to do `git commit` and use the text editor.
 
 Commits must take the form:
-```
+
+```text
 prefix: SHORT MESSAGE
 
 LONGER MESSAGE
@@ -134,7 +135,7 @@ In the `chathistorydisplayer` directory, execute
 docker compose up
 ```
 
-After it is done setting up, `chathistorydisplayer-web` will be accessible from http://localhost:3000/.
+After it is done setting up, `chathistorydisplayer-web` will be accessible from [http://localhost:3000/](http://localhost:3000/).
 
 ## Attaching Bash Terminal
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ This is most useful for attaching a bash terminal to the `chathistorydisplayer-a
 With the [bash terminal attached](#attaching-bash-terminal) to the API, you can execute the tests on the API end-points with the following command:
 
 ```bash
-rspec spec/api-specs/
+rspec spec/api_specs/
 ```
 
 ## Creating a Pull Request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,8 @@
 
 - [Attaching Bash Terminal](#attaching-bash-terminal)
 
+- [Running API Tests](#running-api-tests)
+
 - [Creating a Pull Request](#creating-a-pull-request)
 
 ## Prerequisites
@@ -153,6 +155,15 @@ This is most useful for attaching a bash terminal to the `chathistorydisplayer-a
   ```bash
   docker exec -it chathistorydisplayer-web-1 /bin/bash
   ```
+
+## Running API Tests
+----
+
+With the [bash terminal attached](#attaching-bash-terminal) to the API, you can execute the tests on the API end-points with the following command:
+
+```bash
+rspec spec/api-specs/
+```
 
 ## Creating a Pull Request
 ----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,27 @@
 # CONTRIBUTING.md
 
 ## Contents
+
 ----
 
-- [Prerequisites](#prerequisites)
-
-- [Getting Development Ready](#getting-development-ready)
-
-- [Branching Strategy](#branching-strategy)
-
-  - [Setting Up a Branch](#setting-up-a-branch)
-
-  - [Branch Naming Scheme](#branch-naming-scheme)
-
-- [Commit Strategy](#commit-strategy)
-
-  - [Form of a Commit](#form-of-a-commit)
-
-  - [Present Tense and Imperative Mood](#present-tense-and-imperative-mood)
-
-  - [Prefixes](#prefixes)
-
-- [Running Development Instance](#running-development-instance)
-
-- [Attaching Bash Terminal](#attaching-bash-terminal)
-
-- [Running API Tests](#running-api-tests)
-
-- [Creating a Pull Request](#creating-a-pull-request)
+- [CONTRIBUTING.md](#contributingmd)
+  - [Contents](#contents)
+  - [Prerequisites](#prerequisites)
+  - [Getting Development Ready](#getting-development-ready)
+  - [Branching Strategy](#branching-strategy)
+    - [Setting Up a Branch](#setting-up-a-branch)
+    - [Branch Naming Scheme](#branch-naming-scheme)
+  - [Commit Strategy](#commit-strategy)
+    - [Form of a Commit](#form-of-a-commit)
+    - [Present Tense and Imperative Mood](#present-tense-and-imperative-mood)
+    - [Prefixes](#prefixes)
+  - [Running Development Instance](#running-development-instance)
+  - [Attaching Bash Terminal](#attaching-bash-terminal)
+  - [Running API Tests](#running-api-tests)
+  - [Creating a Pull Request](#creating-a-pull-request)
 
 ## Prerequisites
+
 ----
 
 - A terminal capable of executing `sh` scripts (if you are on Windows, then WSL2, MSYS2, or
@@ -38,6 +30,7 @@
 - Configure git.
 
 ## Getting Development Ready
+
 ----
 
 The [thoth-tech/ChatHistoryDisplayer](https://github.com/thoth-tech/ChatHistoryDisplayer) uses a [forking workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow).
@@ -61,6 +54,7 @@ The [thoth-tech/ChatHistoryDisplayer](https://github.com/thoth-tech/ChatHistoryD
 You can now pull changes from the main branch of [thoth-tech/ChatHistoryDisplayer](https://github.com/thoth-tech/ChatHistoryDisplayer) with `git pull upstream`.
 
 ## Branching Strategy
+
 ----
 
 ### Setting Up a Branch
@@ -97,6 +91,7 @@ It is advised that all branches begin with a prefix followed by a name that expl
 |`fix`    | `fix/rack-config` | Use when fixing something, such as a bug. |
 
 ## Commit Strategy
+
 ----
 
 ### Form of a Commit
@@ -130,9 +125,11 @@ Example:
 | fix | Use when fixing something | `fix: user dir not deleting` |
 
 ## Running Development Instance
+
 ----
 
 In the `chathistorydisplayer` directory, execute
+
 ```bash
 docker compose up
 ```
@@ -140,6 +137,7 @@ docker compose up
 After it is done setting up, `chathistorydisplayer-web` will be accessible from http://localhost:3000/.
 
 ## Attaching Bash Terminal
+
 ----
 
 This is most useful for attaching a bash terminal to the `chathistorydisplayer-api`, as you can use executable Ruby gems with the terminal attached to the container. For example, when the terminal is attached to the running container for the `chathistorydisplayer-api`, you can execute `bundle exec rubocop` to execute the static text analyser and linter `rubocop`.
@@ -157,6 +155,7 @@ This is most useful for attaching a bash terminal to the `chathistorydisplayer-a
   ```
 
 ## Running API Tests
+
 ----
 
 With the [bash terminal attached](#attaching-bash-terminal) to the API, you can execute the tests on the API end-points with the following command:
@@ -166,6 +165,7 @@ rspec spec/api-specs/
 ```
 
 ## Creating a Pull Request
+
 ----
 
 - Visit [thoth-tech/ChatHistoryDisplayer](https://github.com/thoth-tech/ChatHistoryDisplayer).

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 ### Demonstrative Video
 
-A demonstrative video exists, you can find it [inside of the repository](media/demonstration.mp4) or [on YouTube](https://youtu.be/YQ2wFPsoNcA). It showcases how to spin up chathistorydisplayer-api and chathistorydisplayer-web. It also explains some of the important files in both of the applications involved in this repository.
+A demonstrative video exists, you can find it [inside of the repository](media/demonstration.mp4) or [on YouTube](https://youtu.be/YQ2wFPsoNcA). It showcases how to spin up `chathistorydisplayer-api` and `chathistorydisplayer-web`. It also explains some of the important files in both of the applications involved in this repository.
 
 ## Future
 
 It is important that focus is kept on the ultimate goal: the integration into the OnTrack platform.
 
-A [diagram of chathistorydisplayer-api integrated into the OnTrack platform](media/api_proposition.png) is a good artefact to look at, in terms of the future of this repository.
+A [diagram of chathistorydisplayer-api integrated into the OnTrack platform](media/api-proposition.png) is a good artefact to look at, in terms of the future of this repository.
 
 ## Contributing
 

--- a/emulator/main.rb
+++ b/emulator/main.rb
@@ -108,7 +108,12 @@ end
 
 # gets the diff string from the diff file
 get '/diff/:user_id/:project_name/:file_name' do |user_id, project_name, file_name|
-  response = GitGenerator.get_diff_string_from_file(user_id, project_name, file_name)
+  
+  if GitGenerator.file_exist?(user_id, project_name, file_name)
+    response = GitGenerator.get_diff_string_from_file(user_id, project_name, file_name)
+  else
+    response = GitGenerator.file_not_found
+  end
 
   case response
   when :file_not_found

--- a/emulator/main.rb
+++ b/emulator/main.rb
@@ -40,7 +40,7 @@ get '/init/:user_id' do |user_id|
   when :user_creation_success
     Response.generic('201', 'User directory created successfully!')
   when :user_directory_exist
-    Response.generic('401', 'User directory already exists.')
+    Response.generic('404', 'User directory already exists.')
   end
 end
 
@@ -50,9 +50,9 @@ get '/init/:user_id/:project_id' do |user_id, project_id|
 
   case response
   when :project_creation_success
-    Response.generic('200', 'Project directory created successfully!')
+    Response.generic('201', 'Project directory created successfully!')
   when :project_directory_exist
-    Response.generic('401', 'Project directory already exists')
+    Response.generic('404', 'Project directory already exists')
   end
 end
 
@@ -64,9 +64,9 @@ post '/:user_id/:project_name' do |user_id, project_name|
 
   case response
   when :file_creation_success
-    Response.generic('200', 'File created.')
+    Response.generic('201', 'File created.')
   when :project_directory_missing
-    Response.generic('401', 'Project directory missing.')
+    Response.generic('404', 'Project directory missing.')
   end
 end
 
@@ -78,7 +78,7 @@ delete '/:user_id' do |user_id|
   when :user_deletion_success
     Response.generic('201', 'User directory removed successfully!')
   when :user_missing
-    Reponse.generic('401', 'User directory not found.')
+    Reponse.generic('404', 'User directory not found.')
   end
 end
 
@@ -90,7 +90,7 @@ delete '/:user_id/:project_name' do |user_id, project_name|
   when :project_deletion_success
     Response.generic('201', 'Project directory removed successfully!')
   when :project_missing
-    Response.generic('401', 'Project directory not found.')
+    Response.generic('404', 'Project directory not found.')
   end
 end
 
@@ -102,7 +102,7 @@ delete '/:user_id/:project_name/:file_name' do |user_id, project_name, file_name
   when :file_deletion_success
     Response.generic('201', 'File removed successfully!')
   when :file_missing
-    Response.generic('401', 'File not found.')
+    Response.generic('404', 'File not found.')
   end
 end
 
@@ -112,7 +112,7 @@ get '/diff/:user_id/:project_name/:file_name' do |user_id, project_name, file_na
 
   case response
   when :file_not_found
-    Response.generic('401', 'File not found.')
+    Response.generic('404', 'File not found.')
   else
     Response.generic('201', response)
   end
@@ -126,7 +126,7 @@ get '/file_exist/:user_id/:project_name/:file_name' do |user_id, project_name, f
   when true
     Response.generic('201', 'File found.')
   else
-    Response.generic('401', 'File not found.')
+    Response.generic('404', 'File not found.')
   end
 end
 

--- a/emulator/main.rb
+++ b/emulator/main.rb
@@ -28,7 +28,7 @@ end
 # HTTP Response boilerplate
 options '*' do
   response.headers['Access-Control-Allow-Methods'] = 'GET, PUT, POST, DELETE, OPTIONS'
-  response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, Accept, X-User-Email, X-Auth-Token', 'Access-Control-Allow-Origin'
+  response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, Accept, X-User-Email, X-Auth-Token'
 end
 
 # API END-POINTS
@@ -77,8 +77,8 @@ delete '/:user_id' do |user_id|
   case response
   when :user_deletion_success
     Response.generic('201', 'User directory removed successfully!')
-  when :user_missing
-    Reponse.generic('404', 'User directory not found.')
+  else
+    Response.generic('404', 'User directory not found.')
   end
 end
 

--- a/emulator/main.rb
+++ b/emulator/main.rb
@@ -143,8 +143,8 @@ get '/required_files/:user_id/:project_name' do |user_id, project_name|
 
   case response
   when :required_files_found
-    Response.generic('201', true)
+    Response.generic('201', 'File found.')
   when :required_files_not_found
-    Response.generic('404', false)
+    Response.generic('404', 'File not found.')
   end
 end

--- a/emulator/main.rb
+++ b/emulator/main.rb
@@ -106,13 +106,13 @@ delete '/:user_id/:project_name/:file_name' do |user_id, project_name, file_name
   end
 end
 
+#### [TODO] Need to create test case in spec/api_spec
 # gets the diff string from the diff file
 get '/diff/:user_id/:project_name/:file_name' do |user_id, project_name, file_name|
-  
   if GitGenerator.file_exist?(user_id, project_name, file_name)
     response = GitGenerator.get_diff_string_from_file(user_id, project_name, file_name)
   else
-    response = GitGenerator.file_not_found
+    response = :file_not_found
   end
 
   case response
@@ -123,6 +123,7 @@ get '/diff/:user_id/:project_name/:file_name' do |user_id, project_name, file_na
   end
 end
 
+#### [TODO] Need to create test case in spec/api_spec
 # get whether a file exists in a user's project dir
 get '/file_exist/:user_id/:project_name/:file_name' do |user_id, project_name, file_name|
   response = GitGenerator.file_exist?(user_id, project_name, file_name)
@@ -135,6 +136,7 @@ get '/file_exist/:user_id/:project_name/:file_name' do |user_id, project_name, f
   end
 end
 
+#### [TODO] Need to create test case in spec/api_spec
 # get the status of a user's project (are all required files present?)
 get '/required_files/:user_id/:project_name' do |user_id, project_name|
   response = GitGenerator.required_files_exist?(user_id, project_name)

--- a/emulator/main.rb
+++ b/emulator/main.rb
@@ -136,7 +136,7 @@ get '/required_files/:user_id/:project_name' do |user_id, project_name|
 
   case response
   when :required_files_found
-    Response.generic('404', true)
+    Response.generic('201', true)
   when :required_files_not_found
     Response.generic('404', false)
   end

--- a/emulator/main.rb
+++ b/emulator/main.rb
@@ -28,7 +28,7 @@ end
 # HTTP Response boilerplate
 options '*' do
   response.headers['Access-Control-Allow-Methods'] = 'GET, PUT, POST, DELETE, OPTIONS'
-  response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, Accept, X-User-Email, X-Auth-Token'
+  response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, Accept, X-User-Email, X-Auth-Token', 'Access-Control-Allow-Origin'
 end
 
 # API END-POINTS

--- a/emulator/spec/api_specs/creation_spec.rb
+++ b/emulator/spec/api_specs/creation_spec.rb
@@ -1,0 +1,94 @@
+require 'rspec'
+require 'rack/test'
+require 'json'
+require './main'
+
+RSpec.configure do |config|
+    config.include Rack::Test::Methods
+end
+
+PATH = "./users"
+
+RSpec.describe 'chathistorydisplayer-api creation end-points' do
+    include Rack::Test::Methods
+
+    def app
+        Sinatra::Application
+    end
+
+    user_id = 'spec_test_user'
+    project_name = 'spec_test_project'
+    file = { :fileName => 'spec_test_file', :fileContents => 'Test file contents.' }
+
+    # creation of user directory, project directory, and file when these do not already exist
+    describe 'GET /init/user_id' do
+        it 'should return a 201 resource created status code' do
+            get "/init/#{user_id}"
+            json_response = JSON.parse(last_response.body)
+            expect(json_response['Code']).to eq('201')
+        end
+
+        it 'should find a directory' do
+            expect(File.exist?("#{PATH}/#{user_id}")).to be_truthy
+        end
+    end
+
+    describe 'GET /init/user_id/project_name' do
+        it 'should return a 201 resource created status code' do
+            get "/init/#{user_id}/#{project_name}"
+            json_response = JSON.parse(last_response.body)
+            expect(json_response['Code']).to eq('201')
+        end
+
+        it 'should find a directory' do
+            expect(File.exist?("#{PATH}/#{user_id}/#{project_name}")).to be_truthy
+        end
+    end
+
+    describe 'POST /user_id/project_name' do
+        it 'should return a 201 resource created status code' do
+            json_body = {
+                :fileName => file[:fileName],
+                :fileContents => file[:fileContents]
+            }.to_json
+
+            content_type = { 'CONTENT-TYPE' => 'application/json' }
+
+            post "/#{user_id}/#{project_name}", json_body, content_type
+            json_response = JSON.parse(last_response.body)
+            expect(json_response['Code']).to eq('201')
+        end
+
+        it 'should find a directory' do
+            expect(File.exist?("#{PATH}/#{user_id}/#{project_name}/#{file[:fileName]}")).to be_truthy
+        end
+    end
+
+    # test when the user directory and project directory
+    describe 'GET /init/user_id' do
+        it 'should return a 404 resource not found status code' do
+            # ensure the spec_test_user directory already exists
+            get "/init/#{user_id}"
+
+            get "/init/#{user_id}"
+            json_response = JSON.parse(last_response.body)
+            expect(json_response['Code']).to eq('404')
+        end
+    end
+
+    describe 'GET /init/user_id/project_name' do
+        it 'should return a 404 resource not found status code' do
+            # ensure the spec_test_proj directory already exists
+            get "/init/#{user_id}/#{project_name}"
+
+            get "/init/#{user_id}/#{project_name}"
+            json_response = JSON.parse(last_response.body)
+            expect(json_response['Code']).to eq('404')
+        end
+
+        it 'should find a file' do
+            expect(File.exist?("#{PATH}/#{user_id}/#{project_name}")).to be_truthy
+        end
+    end
+
+end

--- a/emulator/spec/api_specs/deletion_spec.rb
+++ b/emulator/spec/api_specs/deletion_spec.rb
@@ -1,0 +1,77 @@
+require 'rspec'
+require 'rack/test'
+require 'json'
+require './main'
+
+RSpec.configure do |config|
+    config.include Rack::Test::Methods
+end
+
+RSpec.describe 'chathistorydisplayer-api deletion end-points' do
+    include Rack::Test::Methods
+
+    def app
+        Sinatra::Application
+    end
+
+    user_id = 'spec_test_user'
+    project_name = 'spec_test_project'
+    file = { :fileName => 'spec_test_file', :fileContents => 'Test file contents.' }
+
+    describe 'DELETE /user_id/project_name/file' do
+        it 'should return a 201 status code' do
+            # create the user directory
+            get "/init/#{user_id}"
+
+            # create the project directory
+            get "/init/#{user_id}/#{project_name}"
+            
+            # create the file
+            json_body = {
+                :fileName => file[:fileName],
+                :fileContents => file[:fileContents]
+            }.to_json
+
+            content_type = { 'CONTENT-TYPE' => 'application/json' }
+
+            post "/#{user_id}/#{project_name}", json_body, content_type
+
+            # delete the file
+            delete "/#{user_id}/#{project_name}/#{file[:fileName]}"
+        end
+
+        it 'should not find the file' do
+            expect(File.exist?("#{PATH}/#{user_id}/#{project_name}/#{file[:fileName]}")).to be_falsy
+        end
+    end
+
+    describe 'DELETE /user_id/project_name' do
+        it 'should return a 201 status code' do
+            # create the user directory
+            get "/init/#{user_id}"
+
+            # create the project directory
+            get "/init/#{user_id}/#{project_name}"
+
+            delete "/#{user_id}/#{project_name}"
+        end
+
+        it 'should not find the directory' do
+            expect(File.exist?("#{PATH}/#{user_id}/#{project_name}")).to be_falsy
+        end
+    end
+
+    describe 'DELETE /user_id' do
+        it 'should return a 201 status code' do
+            # create the user directory
+            get "/init/#{user_id}"
+            
+            delete "/#{user_id}"
+        end
+
+        it 'should not find the directory' do
+            expect(File.exist?("#{PATH}/#{user_id}")).to be_falsy
+        end
+    end
+
+end

--- a/frontEndSimulator/src/App.js
+++ b/frontEndSimulator/src/App.js
@@ -73,6 +73,7 @@ function App() {
       setJsonResponse(response.data)
       setResponse(JSON.stringify(response.data));
       setDiff(response.data["Code"] === "201" ? response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n") : diff);
+      setJsonResponse({"Code": 201, "Message": "Done."})
       setSnackOpen(true);
     }).catch((response) => {
       // API automatically handle invalid URL and comeback with a structured respponse

--- a/frontEndSimulator/src/App.js
+++ b/frontEndSimulator/src/App.js
@@ -72,8 +72,12 @@ function App() {
     axios.get(url).then((response) => {
       setJsonResponse(response.data)
       setResponse(JSON.stringify(response.data));
-      setDiff(response.data["Code"] === "201" ? response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n") : diff);
-      setJsonResponse({"Code": 201, "Message": "Done."})
+      if (response.data["Code"] === "201"){
+        setDiff(response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n"));
+        setJsonResponse({ "Code": 201, "Message": response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n") })
+      }else{
+        setDiff(diff);
+      }
       setSnackOpen(true);
     }).catch((response) => {
       // API automatically handle invalid URL and comeback with a structured respponse
@@ -90,8 +94,9 @@ function App() {
     <Box display="flex" flexDirection="column" alignItems="center">
       <Snackbar
         open={snackOpen}
+        style={{ whiteSpace: 'pre-wrap' }}
         onClose={handleSnackClose}
-        message={jsonResponse["Message"] ? String(jsonResponse["Message"]) :jsonResponse["message"]}
+        message={jsonResponse["Message"] ? jsonResponse["Message"] : jsonResponse["message"]}
         autoHideDuration={3000}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         action={

--- a/frontEndSimulator/src/App.js
+++ b/frontEndSimulator/src/App.js
@@ -70,6 +70,7 @@ function App() {
   function getDiff(endpoint) {
     const url = `http://localhost:4567/${endpoint}`;
     axios.get(url).then((response) => {
+      setJsonResponse(response.data)
       setResponse(JSON.stringify(response.data));
       setDiff(response.data["Code"] === "201" ? response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n") : diff);
       setSnackOpen(true);
@@ -78,7 +79,7 @@ function App() {
       // We should handle to let user know there are an error accure.
       // Should have a snackbar error, simulating OnTrack behavior
 
-      setResponse(JSON.stringify(response.data));
+      setJsonResponse(response)
       setResponse(JSON.stringify(response));
       setSnackOpen(true);
     });
@@ -89,7 +90,7 @@ function App() {
       <Snackbar
         open={snackOpen}
         onClose={handleSnackClose}
-        message={jsonResponse["Message"] ? jsonResponse["Message"] : jsonResponse["message"]}
+        message={jsonResponse["Message"] ? String(jsonResponse["Message"]) :jsonResponse["message"]}
         autoHideDuration={3000}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         action={

--- a/frontEndSimulator/src/App.js
+++ b/frontEndSimulator/src/App.js
@@ -44,7 +44,7 @@ function App() {
     const url = `http://localhost:4567/${endpoint}`;
     axios.get(url).then((response) => {
       setResponse(JSON.stringify(response.data));
-      setDiff(response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n"));
+      setDiff(response.data["Code"] === "201" ? response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n") : diff);
     });
   }
 

--- a/frontEndSimulator/src/App.js
+++ b/frontEndSimulator/src/App.js
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import axios from "axios";
-import { Box, Button, TextField, Table, TableCell, TableRow, TableBody, Paper } from "@mui/material";
+import { Box, Button, TextField, Table, TableCell, TableRow, TableBody, Paper, Snackbar, IconButton } from "@mui/material";
+import { Close as CloseIcon } from '@mui/icons-material';
 import "./styling/index.css";
+import React from 'react';
 
 function App() {
   // State variables
@@ -11,15 +13,28 @@ function App() {
   const [pid, setPID] = useState("");
   const [fileContents, setFileContents] = useState("");
   const [diff, setDiff] = useState("The `git diff` of a file with itself will appear here.");
+  const [snackOpen, setSnackOpen] = React.useState(false);
+  const [jsonResponse, setJsonResponse] = React.useState({});
   const boxWidth = 400;
+
+  const handleSnackClose = (event, reason) => {
+    if (reason === 'clickaway') 
+      return;
+
+    setSnackOpen(false);
+  };
 
   //Get request handler
   function sendGet(endpoint) {
     const url = `http://localhost:4567/${endpoint}`;
     axios.get(url).then((response) => {
+      setJsonResponse(response.data)
       setResponse(JSON.stringify(response.data));
+      setSnackOpen(true);
     }).catch((response) => {
+      setJsonResponse(response)
       setResponse(JSON.stringify(response));
+      setSnackOpen(true);
     });
 
   }
@@ -28,9 +43,13 @@ function App() {
   function sendPost(endpoint, body) {
     const url = `http://localhost:4567/${endpoint}`;
     axios.post(url, body).then((response) => {
+      setJsonResponse(response.data)
       setResponse(JSON.stringify(response.data));
+      setSnackOpen(true);
     }).catch((response) => {
+      setJsonResponse(response)
       setResponse(JSON.stringify(response));
+      setSnackOpen(true);
     });
   }
 
@@ -38,9 +57,13 @@ function App() {
   function deletePost(endpoint, body) {
     const url = `http://localhost:4567/${endpoint}`;
     axios.delete(url, body).then((response) => {
+      setJsonResponse(response.data)
       setResponse(JSON.stringify(response.data));
+      setSnackOpen(true);
     }).catch((response) => {
+      setJsonResponse(response)
       setResponse(JSON.stringify(response));
+      setSnackOpen(true);
     });
   }
 
@@ -49,16 +72,35 @@ function App() {
     axios.get(url).then((response) => {
       setResponse(JSON.stringify(response.data));
       setDiff(response.data["Code"] === "201" ? response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n") : diff);
+      setSnackOpen(true);
     }).catch((response) => {
       // API automatically handle invalid URL and comeback with a structured respponse
       // We should handle to let user know there are an error accure.
       // Should have a snackbar error, simulating OnTrack behavior
+
+      setResponse(JSON.stringify(response.data));
       setResponse(JSON.stringify(response));
+      setSnackOpen(true);
     });
   }
 
   return (
     <Box display="flex" flexDirection="column" alignItems="center">
+      <Snackbar
+        open={snackOpen}
+        onClose={handleSnackClose}
+        message={jsonResponse["Message"] ? jsonResponse["Message"] : jsonResponse["message"]}
+        autoHideDuration={3000}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        action={
+          <React.Fragment>
+            <IconButton size="small" aria-label="close" color="inherit" onClick={handleSnackClose}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </React.Fragment>
+        }
+      />
+
       <Box
         width={boxWidth * 2 + 10}
       >

--- a/frontEndSimulator/src/App.js
+++ b/frontEndSimulator/src/App.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import axios from "axios";
-import { Box, Button, TextField, Table, TableCell, TableRow, TableBody, Paper, Snackbar, IconButton } from "@mui/material";
+import { Box, Button, TextField, Table, TableCell, TableRow, TableBody, Paper, Snackbar, IconButton, Link } from "@mui/material";
 import { Close as CloseIcon } from '@mui/icons-material';
 import "./styling/index.css";
 import React from 'react';
@@ -349,6 +349,8 @@ function App() {
             </TableBody>
           </Table>
         </Paper>
+
+        <Link href="https://github.com/thoth-tech/ChatHistoryDisplayer" target="_blank" rel="noopener noreferrer" variant="body1" fontSize={16} marginTop={2}>Project Repository</Link>
       </Box>
     </Box>
   );

--- a/frontEndSimulator/src/App.js
+++ b/frontEndSimulator/src/App.js
@@ -17,17 +17,20 @@ function App() {
   function sendGet(endpoint) {
     const url = `http://localhost:4567/${endpoint}`;
     axios.get(url).then((response) => {
-      console.log(response.data);
       setResponse(JSON.stringify(response.data));
+    }).catch((response) => {
+      setResponse(JSON.stringify(response));
     });
+
   }
 
   //Post request handler
   function sendPost(endpoint, body) {
     const url = `http://localhost:4567/${endpoint}`;
     axios.post(url, body).then((response) => {
-      console.log(response.data);
       setResponse(JSON.stringify(response.data));
+    }).catch((response) => {
+      setResponse(JSON.stringify(response));
     });
   }
 
@@ -35,8 +38,9 @@ function App() {
   function deletePost(endpoint, body) {
     const url = `http://localhost:4567/${endpoint}`;
     axios.delete(url, body).then((response) => {
-      console.log(response.data);
       setResponse(JSON.stringify(response.data));
+    }).catch((response) => {
+      setResponse(JSON.stringify(response));
     });
   }
 
@@ -45,6 +49,11 @@ function App() {
     axios.get(url).then((response) => {
       setResponse(JSON.stringify(response.data));
       setDiff(response.data["Code"] === "201" ? response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n") : diff);
+    }).catch((response) => {
+      // API automatically handle invalid URL and comeback with a structured respponse
+      // We should handle to let user know there are an error accure.
+      // Should have a snackbar error, simulating OnTrack behavior
+      setResponse(JSON.stringify(response));
     });
   }
 


### PR DESCRIPTION
This pull request
- Updates the response status codes to be in-line with [this resource](https://restfulapi.net/http-status-codes/).
- Fixes the broken image link in the README.md file.
- Adds API end-point tests (via rspec) for:
  - User directory creation.
  - Project directory creation.
  - File creation.
  - User directory deletion.
  - Project directory deletion.
  - File deletion.
- Adds instructions on how to execute the API end-point tests into the CONTRIBUTING.md file.
- Add MUI Snackbar for Error msg
- BUG fix
   - incorrect response code
   - possible null get diff in `GitGenerator.get_diff_string_from_file(...)`
   - possible null match in `response.data["Message"].match(/(^-\w+.*)|(^\+\w+.*)|(^ \w+.*)/gm).join("\n")`
   - handle uncatch empty url request
   - typo in `Response.generic('404', 'User directory not found.')`